### PR TITLE
   - Remove cache: yarn from setup-node to avoid version conflicts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,22 +25,24 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '24'
-          cache: 'yarn'
+
+      - name: Enable Corepack
+        run: corepack enable
 
       - name: Install dependencies
-        run: yarn install --frozen-lockfile
+        run: corepack yarn install --frozen-lockfile
 
       - name: Run linter
-        run: yarn lint
-
-      - name: Run tests
-        run: yarn test:all
-
-      - name: Run tests with coverage
-        run: yarn test:coverage
+        run: corepack yarn lint
 
       - name: Build
-        run: yarn build
+        run: corepack yarn build
+
+      - name: Run tests
+        run: corepack yarn test:all
+
+      - name: Run tests with coverage
+        run: corepack yarn test:coverage
 
   security:
     runs-on: ubuntu-latest
@@ -53,13 +55,15 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '24'
-          cache: 'yarn'
+
+      - name: Enable Corepack
+        run: corepack enable
 
       - name: Install dependencies
-        run: yarn install --frozen-lockfile
+        run: corepack yarn install --frozen-lockfile
 
       - name: Run yarn audit
-        run: yarn audit --level moderate
+        run: corepack yarn audit --level moderate
         continue-on-error: true
 
       - name: Run Trivy security scanner

--- a/.github/workflows/deploy-master.yml
+++ b/.github/workflows/deploy-master.yml
@@ -28,13 +28,15 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '24'
-          cache: 'yarn'
+
+      - name: Enable Corepack
+        run: corepack enable
 
       - name: Install dependencies
-        run: yarn install --frozen-lockfile
+        run: corepack yarn install --frozen-lockfile
 
       - name: Build
-        run: yarn build
+        run: corepack yarn build
 
       - name: Setup AWS SAM CLI
         uses: aws-actions/setup-sam@v2
@@ -108,13 +110,15 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '24'
-          cache: 'yarn'
+
+      - name: Enable Corepack
+        run: corepack enable
 
       - name: Install dependencies
-        run: yarn install --frozen-lockfile
+        run: corepack yarn install --frozen-lockfile
 
       - name: Build
-        run: yarn build
+        run: corepack yarn build
 
       - name: Setup AWS SAM CLI
         uses: aws-actions/setup-sam@v2

--- a/.github/workflows/deploy-pr.yml
+++ b/.github/workflows/deploy-pr.yml
@@ -31,13 +31,15 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '24'
-          cache: 'yarn'
+
+      - name: Enable Corepack
+        run: corepack enable
 
       - name: Install dependencies
-        run: yarn install --frozen-lockfile
+        run: corepack yarn install --frozen-lockfile
 
       - name: Build
-        run: yarn build
+        run: corepack yarn build
 
       - name: Setup AWS SAM CLI
         uses: aws-actions/setup-sam@v2


### PR DESCRIPTION
   - Use 'corepack yarn' instead of 'yarn' to ensure correct version
   - Reorder CI steps to build before tests (integration tests need dist/)
   - Fixes: Yarn 1.22.22 vs 4.12.0 version mismatch errors